### PR TITLE
🔒 Fix reverse tabnabbing vulnerability

### DIFF
--- a/src/components/sections/Contact/Contact.jsx
+++ b/src/components/sections/Contact/Contact.jsx
@@ -23,7 +23,7 @@ const Contact = ({ links }) => {
               <ExternalLink size={14} className={styles.arrow} />
             </a>
 
-            <a href={links.linkedin} target="_blank" rel="noreferrer" className={styles.contactLink}>
+            <a href={links.linkedin} target="_blank" rel="noopener noreferrer" className={styles.contactLink}>
               <div className={styles.iconBox}>
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
               </div>
@@ -34,7 +34,7 @@ const Contact = ({ links }) => {
               <ExternalLink size={14} className={styles.arrow} />
             </a>
 
-            <a href={links.github} target="_blank" rel="noreferrer" className={styles.contactLink}>
+            <a href={links.github} target="_blank" rel="noopener noreferrer" className={styles.contactLink}>
               <div className={styles.iconBox}>
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path><path d="M9 18c-4.51 2-5-2-7-2"></path></svg>
               </div>
@@ -45,7 +45,7 @@ const Contact = ({ links }) => {
               <ExternalLink size={14} className={styles.arrow} />
             </a>
 
-            <a href={links.resume} target="_blank" rel="noreferrer" className={styles.contactLink}>
+            <a href={links.resume} target="_blank" rel="noopener noreferrer" className={styles.contactLink}>
               <div className={styles.iconBox}>
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
               </div>

--- a/src/components/sections/Hero/Hero.jsx
+++ b/src/components/sections/Hero/Hero.jsx
@@ -27,17 +27,17 @@ const Hero = ({ profile = {} }) => {
         <div className={styles.heroDescend}>
           <div className={styles.descendLinks}>
             {links.github && (
-              <a href={links.github} target="_blank" rel="noreferrer" aria-label="GitHub Profile">
+              <a href={links.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile">
                 <GitBranch size={20} />
               </a>
             )}
             {links.linkedin && (
-              <a href={links.linkedin} target="_blank" rel="noreferrer" aria-label="LinkedIn Profile">
+              <a href={links.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile">
                 <Briefcase size={20} />
               </a>
             )}
             {links.resume && (
-              <a href={links.resume} target="_blank" rel="noreferrer" aria-label="Resume">
+              <a href={links.resume} target="_blank" rel="noopener noreferrer" aria-label="Resume">
                 <FileText size={20} />
               </a>
             )}

--- a/src/components/sections/Projects/ProjectCard.jsx
+++ b/src/components/sections/Projects/ProjectCard.jsx
@@ -29,12 +29,12 @@ const ProjectCard = ({ project, onClick }) => {
         
         <div className={`${styles.projectLinks} mono-accent`}>
           {project.github && (
-            <a href={project.github} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>
+            <a href={project.github} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
               <GitBranch size={14} /> SOURCE
             </a>
           )}
           {project.demo && (
-            <a href={project.demo} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>
+            <a href={project.demo} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
               <ExternalLink size={14} /> EXPLORE
             </a>
           )}


### PR DESCRIPTION
🎯 **What:** Fixed reverse tabnabbing vulnerability by ensuring all links opening in a new tab (`target="_blank"`) use `rel="noopener noreferrer"`.
⚠️ **Risk:** Without `noopener`, malicious external websites could gain control of the original window (via `window.opener`), redirecting the user to a phishing site.
🛡️ **Solution:** Added `noopener` to `rel` attributes for all external links across `Contact.jsx`, `Hero.jsx`, and `ProjectCard.jsx`.

---
*PR created automatically by Jules for task [1245508160670335856](https://jules.google.com/task/1245508160670335856) started by @Dr-Huitzil*